### PR TITLE
maybe a typo in the file real_time_clock.h

### DIFF
--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -55,7 +55,7 @@ struct ESPTime {
 
   /// Check if all time fields of this ESPTime are in range.
   bool fields_in_range() const {
-    return this->second < 61 && this->minute < 60 && this->hour < 24 && this->day_of_week > 0 &&
+    return this->second < 60 && this->minute < 60 && this->hour < 24 && this->day_of_week > 0 &&
            this->day_of_week < 8 && this->day_of_month > 0 && this->day_of_month < 32 && this->day_of_year > 0 &&
            this->day_of_year < 367 && this->month > 0 && this->month < 13;
   }


### PR DESCRIPTION
seconds must be in the range up to <60 as well as minutes

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes typo

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
